### PR TITLE
Added shortCommandPrefix feature + more volume in/decreases

### DIFF
--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -160,6 +160,7 @@ func (bot *MusicBot) handleMessage(message Message) {
 	if strings.HasPrefix(message.Message, bot.config.CommandPrefix+" ") {
 		message.Message = strings.TrimPrefix(message.Message, bot.config.CommandPrefix+" ")
 		bot.handleCommand(message)
+		return
 	}
 	if strings.HasPrefix(message.Message, bot.config.ShortCommandPrefix) {
 		// either with or without space after the ShortPrefix is fine

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -164,11 +164,7 @@ func (bot *MusicBot) handleMessage(message Message) {
 	}
 	if strings.HasPrefix(message.Message, bot.config.ShortCommandPrefix) {
 		// either with or without space after the ShortPrefix is fine
-		if strings.HasPrefix(message.Message, bot.config.ShortCommandPrefix+" ") {
-			message.Message = strings.TrimPrefix(message.Message, bot.config.ShortCommandPrefix+" ")
-		} else {
-			message.Message = strings.TrimPrefix(message.Message, bot.config.ShortCommandPrefix)
-		}
+		message.Message = strings.TrimSpace(strings.TrimPrefix(message.Message, bot.config.ShortCommandPrefix))
 		bot.handleCommand(message)
 	}
 }
@@ -189,7 +185,7 @@ func (bot *MusicBot) handleCommand(message Message) {
 		}
 
 		if command.MasterOnly && bot.config.Master != message.Sender.Name {
-			bot.ReplyToMessage(message, "this command is for masters only")
+			bot.ReplyToMessage(message, "This command is for masters only")
 			return
 		}
 

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -2,25 +2,30 @@ package bot
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/svenwiltink/go-musicbot/pkg/music"
 	"strconv"
+	"strings"
 	"time"
 )
 
 type Command struct {
 	Name       string
+	Aliases    []string
 	MasterOnly bool
 	Function   func(bot *MusicBot, message Message)
 }
 
 var helpCommand = Command{
-	Name: "help",
+	Name:    "help",
+	Aliases: []string{"h"},
 	Function: func(bot *MusicBot, message Message) {
 		helpString := "Available commands: "
 		for _, command := range bot.commands {
-			helpString += command.Name + " "
+			helpString += command.Name
+			if len(command.Aliases) > 0 {
+				helpString += "[" + strings.Join(command.Aliases, ", ") + "]"
+			}
+			helpString += " "
 		}
 
 		bot.ReplyToMessage(message, helpString)
@@ -35,16 +40,17 @@ func sanitizeSong(song string) string {
 }
 
 var addCommand = Command{
-	Name: "add",
+	Name:    "add",
+	Aliases: []string{"a"},
 	Function: func(bot *MusicBot, message Message) {
-		words := strings.SplitN(message.Message, " ", 3)
-		if len(words) <= 2 {
+		parameter, cmdParamError := message.getCommandParameter()
+		if cmdParamError != nil {
 			bot.ReplyToMessage(message, "No song provided")
 			return
 		}
 
 		song := music.Song{
-			Path: sanitizeSong(words[2]),
+			Path: sanitizeSong(parameter),
 		}
 
 		song, err := bot.musicPlayer.AddSong(song)
@@ -62,15 +68,16 @@ var addCommand = Command{
 }
 
 var searchCommand = Command{
-	Name: "search",
+	Name:    "search",
+	Aliases: []string{"s"},
 	Function: func(bot *MusicBot, message Message) {
-		words := strings.SplitN(message.Message, " ", 3)
-		if len(words) <= 2 {
+		parameter, cmdParamError := message.getCommandParameter()
+		if cmdParamError != nil {
 			bot.ReplyToMessage(message, "No song provided")
 			return
 		}
 
-		songs, err := bot.musicPlayer.Search(strings.TrimSpace(words[2]))
+		songs, err := bot.musicPlayer.Search(parameter)
 
 		if err != nil {
 			bot.ReplyToMessage(message, fmt.Sprintf("error: %v", err))
@@ -93,15 +100,16 @@ var searchCommand = Command{
 }
 
 var searchAddCommand = Command{
-	Name: "search-add",
+	Name:    "search-add",
+	Aliases: []string{"sa"},
 	Function: func(bot *MusicBot, message Message) {
-		words := strings.SplitN(message.Message, " ", 3)
-		if len(words) <= 2 {
+		parameter, cmdParamError := message.getCommandParameter()
+		if cmdParamError != nil {
 			bot.ReplyToMessage(message, "No song provided")
 			return
 		}
 
-		songs, err := bot.musicPlayer.Search(strings.TrimSpace(words[2]))
+		songs, err := bot.musicPlayer.Search(parameter)
 
 		if err != nil {
 			bot.ReplyToMessage(message, fmt.Sprintf("error: %v", err))
@@ -129,7 +137,8 @@ var searchAddCommand = Command{
 }
 
 var nextCommand = Command{
-	Name: "next",
+	Name:    "next",
+	Aliases: []string{"n"},
 	Function: func(bot *MusicBot, message Message) {
 		err := bot.musicPlayer.Next()
 		if err != nil {
@@ -144,7 +153,8 @@ var nextCommand = Command{
 }
 
 var pausedCommand = Command{
-	Name: "pause",
+	Name:    "pause",
+	Aliases: []string{},
 	Function: func(bot *MusicBot, message Message) {
 		err := bot.musicPlayer.Pause()
 		if err != nil {
@@ -162,7 +172,8 @@ var pausedCommand = Command{
 }
 
 var playCommand = Command{
-	Name: "play",
+	Name:    "play",
+	Aliases: []string{},
 	Function: func(bot *MusicBot, message Message) {
 		err := bot.musicPlayer.Play()
 		if err != nil {
@@ -180,7 +191,8 @@ var playCommand = Command{
 }
 
 var currentCommand = Command{
-	Name: "current",
+	Name:    "current",
+	Aliases: []string{"c"},
 	Function: func(bot *MusicBot, message Message) {
 		song, durationLeft := bot.musicPlayer.GetCurrentSong()
 		if song == nil {
@@ -201,7 +213,8 @@ var currentCommand = Command{
 }
 
 var queueCommand = Command{
-	Name: "queue",
+	Name:    "queue",
+	Aliases: []string{"q"},
 	Function: func(bot *MusicBot, message Message) {
 		queue := bot.GetMusicPlayer().GetQueue()
 
@@ -223,7 +236,8 @@ var queueCommand = Command{
 }
 
 var flushCommand = Command{
-	Name: "flush",
+	Name:    "flush",
+	Aliases: []string{"f"},
 	Function: func(bot *MusicBot, message Message) {
 		bot.musicPlayer.GetQueue().Flush()
 
@@ -236,7 +250,8 @@ var flushCommand = Command{
 }
 
 var shuffleCommand = Command{
-	Name: "shuffle",
+	Name:    "shuffle",
+	Aliases: []string{},
 	Function: func(bot *MusicBot, message Message) {
 		bot.musicPlayer.GetQueue().Shuffle()
 
@@ -250,28 +265,23 @@ var shuffleCommand = Command{
 
 var whiteListCommand = Command{
 	Name:       "whitelist",
+	Aliases:    []string{},
 	MasterOnly: true,
 	Function: func(bot *MusicBot, message Message) {
-		words := strings.SplitN(message.Message, " ", 4)
-		if len(words) <= 3 {
+		addOrRemove, name, secCmdVarErr := message.getDualCommandParameters()
+		if secCmdVarErr != nil {
 			bot.ReplyToMessage(message, "whitelist <add|remove> <name>")
 			return
 		}
 
-		name := strings.TrimSpace(words[3])
-		if len(name) == 0 {
-			bot.ReplyToMessage(message, "whitelist <add|remove> <name>")
-			return
-		}
-
-		if words[2] == "add" {
+		if addOrRemove == "add" {
 			err := bot.whitelist.Add(name)
 			if err == nil {
 				bot.ReplyToMessage(message, fmt.Sprintf("added %s to the whitelist", name))
 			} else {
 				bot.ReplyToMessage(message, fmt.Sprintf("error: %v", err))
 			}
-		} else if words[2] == "remove" {
+		} else if addOrRemove == "remove" {
 			err := bot.whitelist.Remove(name)
 			if err == nil {
 				bot.ReplyToMessage(message, fmt.Sprintf("removed %s from the whitelist", name))
@@ -286,11 +296,12 @@ var whiteListCommand = Command{
 }
 
 var volCommand = Command{
-	Name: "vol",
+	Name:    "vol",
+	Aliases: []string{"v"},
 	Function: func(bot *MusicBot, message Message) {
-		words := strings.SplitN(message.Message, " ", 3)
+		volumeString, commandVariableErr := message.getCommandParameter()
 
-		if len(words) == 2 {
+		if commandVariableErr != nil {
 			volume, err := bot.musicPlayer.GetVolume()
 
 			if err != nil {
@@ -303,11 +314,18 @@ var volCommand = Command{
 		}
 
 		// init vars here so we can use them after the switch statement
-		volumeString := strings.TrimSpace(words[2])
 		var volume int
 		var err error
 
 		switch volumeString {
+		case "+":
+			{
+				volume, err = bot.musicPlayer.IncreaseVolume(5)
+				if err != nil {
+					bot.ReplyToMessage(message, fmt.Sprintf("unable to increase volume: %s", err))
+					return
+				}
+			}
 		case "++":
 			{
 				volume, err = bot.musicPlayer.IncreaseVolume(10)
@@ -316,9 +334,33 @@ var volCommand = Command{
 					return
 				}
 			}
+		case "+++":
+			{
+				volume, err = bot.musicPlayer.IncreaseVolume(20)
+				if err != nil {
+					bot.ReplyToMessage(message, fmt.Sprintf("unable to increase volume: %s", err))
+					return
+				}
+			}
+		case "-":
+			{
+				volume, err = bot.musicPlayer.DecreaseVolume(5)
+				if err != nil {
+					bot.ReplyToMessage(message, fmt.Sprintf("unable to decrease volume: %s", err))
+					return
+				}
+			}
 		case "--":
 			{
 				volume, err = bot.musicPlayer.DecreaseVolume(10)
+				if err != nil {
+					bot.ReplyToMessage(message, fmt.Sprintf("unable to decrease volume: %s", err))
+					return
+				}
+			}
+		case "---":
+			{
+				volume, err = bot.musicPlayer.DecreaseVolume(20)
 				if err != nil {
 					bot.ReplyToMessage(message, fmt.Sprintf("unable to decrease volume: %s", err))
 					return

--- a/pkg/bot/config.go
+++ b/pkg/bot/config.go
@@ -11,8 +11,9 @@ import (
 const (
 	DefaultConfigFileLocation = "config.json"
 	DefaultWhiteListFile      = "whitelist.txt"
-	DefauultMaster            = "swiltink"
+	DefaultMaster             = "swiltink"
 	DefaultCommandPrefix      = "!music"
+	DefaultShortCommandPrefix = "!m"
 )
 
 type SlackConfig struct {
@@ -22,17 +23,18 @@ type SlackConfig struct {
 }
 
 type Config struct {
-	WhiteListFile string           `json:"whitelistFile"`
-	Master        string           `json:"master"`
-	Irc           IRCConfig        `json:"irc"`
-	Rocketchat    RocketchatConfig `json:"rocketchat"`
-	Mattermost    MattermostConfig `json:"mattermost"`
-	Slack         SlackConfig      `json:"slack"`
-	Youtube       YoutubeConfig    `json:"youtube"`
-	MessagePlugin string           `json:"messageplugin"`
-	CommandPrefix string           `json:"commandprefix"`
-	MpvPath       string           `json:"mpvpath"`
-	MpvSocket     string           `json:"mpvsocket"`
+	WhiteListFile      string           `json:"whitelistFile"`
+	Master             string           `json:"master"`
+	Irc                IRCConfig        `json:"irc"`
+	Rocketchat         RocketchatConfig `json:"rocketchat"`
+	Mattermost         MattermostConfig `json:"mattermost"`
+	Slack              SlackConfig      `json:"slack"`
+	Youtube            YoutubeConfig    `json:"youtube"`
+	MessagePlugin      string           `json:"messageplugin"`
+	CommandPrefix      string           `json:"commandprefix"`
+	ShortCommandPrefix string           `json:"shortcommandprefix"`
+	MpvPath            string           `json:"mpvpath"`
+	MpvSocket          string           `json:"mpvsocket"`
 }
 
 type IRCConfig struct {
@@ -67,8 +69,9 @@ type YoutubeConfig struct {
 
 func (config *Config) applyDefaults() {
 	config.WhiteListFile = DefaultWhiteListFile
-	config.Master = DefauultMaster
+	config.Master = DefaultMaster
 	config.CommandPrefix = DefaultCommandPrefix
+	config.ShortCommandPrefix = DefaultShortCommandPrefix
 	config.Mattermost.ConnectionTimeout = 30
 }
 

--- a/pkg/bot/message.go
+++ b/pkg/bot/message.go
@@ -1,5 +1,9 @@
 package bot
 
+import (
+	"strings"
+)
+
 type Sender struct {
 	Name     string
 	NickName string
@@ -10,4 +14,40 @@ type Message struct {
 	Sender    Sender
 	Target    string
 	IsPrivate bool
+}
+
+func (message Message) getCommandWord() string {
+	words := strings.SplitN(message.Message, " ", 2)
+	return strings.TrimSpace(words[0])
+}
+
+func (message Message) getCommandParameter() (string, error) {
+	parameters := strings.SplitN(message.Message, " ", 2)
+	if len(parameters) <= 1 {
+		return "", errVariableNotFound
+	}
+
+	parameter := strings.TrimSpace(parameters[1])
+
+	if parameter == "" {
+		return "", errVariableNotFound
+	}
+
+	return parameter, nil
+}
+
+func (message Message) getDualCommandParameters() (string, string, error) {
+	parameters := strings.SplitN(message.Message, " ", 3)
+	if len(parameters) <= 2 {
+		return "", "", errVariableNotFound
+	}
+
+	parameter1 := strings.TrimSpace(parameters[1])
+	parameter2 := strings.TrimSpace(parameters[2])
+
+	if parameter1 == "" || parameter2 == "" {
+		return "", "", errVariableNotFound
+	}
+
+	return parameter1, parameter2, nil
 }

--- a/pkg/music/dataprovider/nts/nts.go
+++ b/pkg/music/dataprovider/nts/nts.go
@@ -5,21 +5,21 @@ import (
 	"github.com/svenwiltink/go-musicbot/pkg/music"
 )
 
-var streams = map[string]string {
-	"nts1": "https://stream-relay-geo.ntslive.net/stream",
-	"nts2": "https://stream-relay-geo.ntslive.net/stream2",
-	"nts-feelings": "https://stream-mixtape-geo.ntslive.net/mixtape27",
-	"nts-field": "https://stream-mixtape-geo.ntslive.net/mixtape23",
-	"nts-memorylane": "https://stream-mixtape-geo.ntslive.net/mixtape6",
+var streams = map[string]string{
+	"nts1":            "https://stream-relay-geo.ntslive.net/stream",
+	"nts2":            "https://stream-relay-geo.ntslive.net/stream2",
+	"nts-feelings":    "https://stream-mixtape-geo.ntslive.net/mixtape27",
+	"nts-field":       "https://stream-mixtape-geo.ntslive.net/mixtape23",
+	"nts-memorylane":  "https://stream-mixtape-geo.ntslive.net/mixtape6",
 	"nts-4tothefloor": "https://stream-mixtape-geo.ntslive.net/mixtape5",
-	"nts-thetube": "https://stream-mixtape-geo.ntslive.net/mixtape26",
-	"nts-lowkey": "https://stream-mixtape-geo.ntslive.net/mixtape2",
-	"nts-island": "https://stream-mixtape-geo.ntslive.net/mixtape21",
-	"nts-raphouse": "https://stream-mixtape-geo.ntslive.net/mixtape22",
-	"nts-sweat": "https://stream-mixtape-geo.ntslive.net/mixtape24",
-	"nts-poolside": "https://stream-mixtape-geo.ntslive.net/mixtape4",
-	"nts-slowfocus": "https://stream-mixtape-geo.ntslive.net/mixtape",
-	"nts-expansions": "https://stream-mixtape-geo.ntslive.net/mixtape3",
+	"nts-thetube":     "https://stream-mixtape-geo.ntslive.net/mixtape26",
+	"nts-lowkey":      "https://stream-mixtape-geo.ntslive.net/mixtape2",
+	"nts-island":      "https://stream-mixtape-geo.ntslive.net/mixtape21",
+	"nts-raphouse":    "https://stream-mixtape-geo.ntslive.net/mixtape22",
+	"nts-sweat":       "https://stream-mixtape-geo.ntslive.net/mixtape24",
+	"nts-poolside":    "https://stream-mixtape-geo.ntslive.net/mixtape4",
+	"nts-slowfocus":   "https://stream-mixtape-geo.ntslive.net/mixtape",
+	"nts-expansions":  "https://stream-mixtape-geo.ntslive.net/mixtape3",
 }
 
 type DataProvider struct{}
@@ -38,8 +38,8 @@ func (DataProvider) ProvideData(song *music.Song) error {
 }
 
 func (DataProvider) Search(name string) ([]music.Song, error) {
-	fmt.Println("trying to search NTS ", name)
 	if name == "nts" {
+		fmt.Println("trying to search NTS ", name)
 		songs := make([]music.Song, 0, len(streams))
 
 		for stream, _ := range streams {


### PR DESCRIPTION
shortCommandPrefix to reduce amount of typing required to do commands. current behavior should not be affected.
also added some extra switchcases to set volume more of less gradually.

 examples:
```
<sepa> !mh
<MusicBot> Available commands: flush[f] vol[v] help[h] pause shuffle play queue[q] whitelist about search[s] search-add[sa] current[c] add[a] next[n]
<sepa> !mv 50
<MusicBot> Volume set to 50
<sepa> !msa paul kalkbrenner battery park
<MusicBot> Paul Kalkbrenner - Topic: Battery Park added
<sepa> !mv -
<MusicBot> Volume set to 45
<sepa> !mv --
<MusicBot> Volume set to 35
<sepa> !mv ---
<MusicBot> Volume set to 15
```